### PR TITLE
Improved filter entities function based on Mark's suggestion

### DIFF
--- a/class/Controllers/Resources/PeopleController.php
+++ b/class/Controllers/Resources/PeopleController.php
@@ -4,8 +4,25 @@ namespace Passle\PassleSync\Controllers\Resources;
 
 use Passle\PassleSync\Controllers\Resources\ResourceControllerBase;
 use Passle\PassleSync\Models\Resources\PersonResource;
+use Passle\PassleSync\Services\OptionsService;
 
 class PeopleController extends ResourceControllerBase
 {
   const RESOURCE = PersonResource::class;
+
+  public static function filter_entities_before_sync(array $entities)
+  {
+    $passle_shortcodes = OptionsService::get()->passle_shortcodes;
+
+    $filtered_entities = [];
+    foreach ($entities as $entity) {
+      foreach ($entity["PassleShortcodes"] as $shortcode) {
+        in_array($shortcode, $passle_shortcodes) ? array_push($filtered_entities, $entity) : null;
+      }
+    }
+
+    $entities = array_unique($filtered_entities);
+
+    return $entities;
+  }
 }

--- a/class/Controllers/Resources/PostsController.php
+++ b/class/Controllers/Resources/PostsController.php
@@ -4,8 +4,18 @@ namespace Passle\PassleSync\Controllers\Resources;
 
 use Passle\PassleSync\Controllers\Resources\ResourceControllerBase;
 use Passle\PassleSync\Models\Resources\PostResource;
+use Passle\PassleSync\Services\OptionsService;
 
 class PostsController extends ResourceControllerBase
 {
   const RESOURCE = PostResource::class;
+
+  public static function filter_entities_before_sync($entities)
+  {
+    $passle_shortcodes = OptionsService::get()->passle_shortcodes;
+
+    $entities = array_filter($entities, fn ($entity) => in_array($entity["PassleShortcode"], $passle_shortcodes));
+
+    return $entities;
+  }
 }


### PR DESCRIPTION
The general function (`filter_entities_before_sync`) that was left in the ResourceControllerBase was converted into an abstract function instead of a virtual one. Reason being that filtering will depend on what entity type it is, so it will either go to the people or posts controller.

So I'm unsure of how we could implement a general filter function for the ResourceControllerBase if we made it virtual.

What do you think @Blondemonk?