### PR TITLE
Added functionality so that passle sync plugin can create categories based off passle tag groups

### DIFF
--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,6 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
+      $params["includeTagsInCategories"]
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,7 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
-      $params["includeTagsInCategories"],
+      $params["includeCategoriesFromPassleTagGroups"],
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,7 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
-      $params["includeTagsInCategories"]
+      $params["includeTagsInCategories"],
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Models/Admin/Options.php
+++ b/class/Models/Admin/Options.php
@@ -16,6 +16,7 @@ class Options implements JsonSerializable
   public bool $simulate_remote_hosting;
   public bool $include_passle_posts_on_home_page;
   public bool $include_passle_posts_on_tag_page;
+  public bool $include_tags_in_categories;
   public string $domain_ext;
   public string $site_url;
 
@@ -30,6 +31,7 @@ class Options implements JsonSerializable
     bool $simulate_remote_hosting,
     bool $include_passle_posts_on_home_page,
     bool $include_passle_posts_on_tag_page,
+    bool $include_tags_in_categories,
     string $domain_ext,
     string $site_url
   ) {
@@ -42,6 +44,7 @@ class Options implements JsonSerializable
     $this->simulate_remote_hosting = $simulate_remote_hosting;
     $this->include_passle_posts_on_home_page = $include_passle_posts_on_home_page;
     $this->include_passle_posts_on_tag_page = $include_passle_posts_on_tag_page;
+    $this->include_tags_in_categories = $include_tags_in_categories;
     $this->domain_ext = $domain_ext;
     $this->site_url = $site_url;
   }
@@ -58,6 +61,7 @@ class Options implements JsonSerializable
       "simulateRemoteHosting" => $this->simulate_remote_hosting,
       "includePasslePostsOnHomePage" => isset($this->include_passle_posts_on_home_page) ? $this->include_passle_posts_on_home_page : false,
       "includePasslePostsOnTagPage" => isset($this->include_passle_posts_on_tag_page) ? $this->include_passle_posts_on_tag_page : false,
+      "includeTagsInCategories" => isset($this->include_tags_in_categories) ? $this->include_tags_in_categories : false,
       "domainExt" => $this->domain_ext,
       "siteUrl" => $this->site_url,
     ];

--- a/class/Models/Admin/Options.php
+++ b/class/Models/Admin/Options.php
@@ -16,7 +16,7 @@ class Options implements JsonSerializable
   public bool $simulate_remote_hosting;
   public bool $include_passle_posts_on_home_page;
   public bool $include_passle_posts_on_tag_page;
-  public bool $include_tags_in_categories;
+  public bool $include_categories_from_passle_tag_groups;
   public string $domain_ext;
   public string $site_url;
 
@@ -31,7 +31,7 @@ class Options implements JsonSerializable
     bool $simulate_remote_hosting,
     bool $include_passle_posts_on_home_page,
     bool $include_passle_posts_on_tag_page,
-    bool $include_tags_in_categories,
+    bool $include_categories_from_passle_tag_groups,
     string $domain_ext,
     string $site_url
   ) {
@@ -44,7 +44,7 @@ class Options implements JsonSerializable
     $this->simulate_remote_hosting = $simulate_remote_hosting;
     $this->include_passle_posts_on_home_page = $include_passle_posts_on_home_page;
     $this->include_passle_posts_on_tag_page = $include_passle_posts_on_tag_page;
-    $this->include_tags_in_categories = $include_tags_in_categories;
+    $this->include_categories_from_passle_tag_groups = $include_categories_from_passle_tag_groups;
     $this->domain_ext = $domain_ext;
     $this->site_url = $site_url;
   }
@@ -61,7 +61,7 @@ class Options implements JsonSerializable
       "simulateRemoteHosting" => $this->simulate_remote_hosting,
       "includePasslePostsOnHomePage" => isset($this->include_passle_posts_on_home_page) ? $this->include_passle_posts_on_home_page : false,
       "includePasslePostsOnTagPage" => isset($this->include_passle_posts_on_tag_page) ? $this->include_passle_posts_on_tag_page : false,
-      "includeTagsInCategories" => isset($this->include_tags_in_categories) ? $this->include_tags_in_categories : false,
+      "includeCategoriesFromPassleTagGroups" => isset($this->include_categories_from_passle_tag_groups) ? $this->include_categories_from_passle_tag_groups : false,
       "domainExt" => $this->domain_ext,
       "siteUrl" => $this->site_url,
     ];

--- a/class/PostTypes/CptBase.php
+++ b/class/PostTypes/CptBase.php
@@ -57,7 +57,6 @@ abstract class CptBase extends ResourceClassBase
       ],
       "hierarchical" => false,
       "supports" => ["title", "custom-fields"],
-      "taxonomies" => ["post_tag"],
       "has_archive" => true,
       "rewrite" => false,
       "query_var" => true,

--- a/class/PostTypes/PasslePostCpt.php
+++ b/class/PostTypes/PasslePostCpt.php
@@ -13,7 +13,7 @@ class PasslePostCpt extends CptBase
   {
     return [
       "menu_icon" => "dashicons-admin-post",
-      "taxonomies" => ["post_tag"],
+      "taxonomies" => ["category", "post_tag"],
     ];
   }
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -57,7 +57,9 @@ abstract class PassleContentServiceBase extends ResourceClassBase
 
   public static function fetch_all()
   {
-    $passle_shortcodes = OptionsService::get()->passle_shortcodes;
+    $options = OptionsService::get();
+
+    $passle_shortcodes = $options->passle_shortcodes;
 
     /** @var array[] $results */
     $results = array_map(fn ($passle_shortcode) => static::fetch_all_by_passle($passle_shortcode), $passle_shortcodes);
@@ -86,14 +88,23 @@ abstract class PassleContentServiceBase extends ResourceClassBase
   public static function fetch_all_by_passle(string $passle_shortcode)
   {
     $resource = static::get_resource_instance();
+    $options = OptionsService::get();
+
+    $path = "passlesync/{$resource->name_plural}";
+    
+    $parameters = array(
+      "PassleShortcode" => $passle_shortcode,
+      "ItemsPerPage" => "100"
+    );
+
+    if ($options->include_tags_in_categories) {
+        $parameters["IncludeTagGroups"] = "true";
+    }
 
     $url = (new UrlFactory())
-      ->path("passlesync/{$resource->name_plural}")
-      ->parameters([
-        "PassleShortcode" => $passle_shortcode,
-        "ItemsPerPage" => "100"
-      ])
-      ->build();
+        ->path($path)
+        ->parameters($parameters)
+        ->build();
 
     $responses = static::get_all_paginated($url);
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -97,7 +97,7 @@ abstract class PassleContentServiceBase extends ResourceClassBase
       "ItemsPerPage" => "100"
     );
 
-    if ($options->include_tags_in_categories) {
+    if ($options->include_categories_from_passle_tag_groups) {
         $parameters["IncludeTagGroups"] = "true";
     }
 
@@ -125,10 +125,15 @@ abstract class PassleContentServiceBase extends ResourceClassBase
   public static function fetch_multiple_by_shortcode(array $entity_shortcodes)
   {
     $resource = static::get_resource_instance();
+    $options = OptionsService::get();
 
     $params = [
       $resource->get_api_parameter_shortcode_name() => join(",", $entity_shortcodes)
     ];
+
+    if ($options->include_categories_from_passle_tag_groups) {
+        $params["IncludeTagGroups"] = "true";
+    }
 
     $factory = new UrlFactory();
     $url = $factory

--- a/class/Services/OptionsService.php
+++ b/class/Services/OptionsService.php
@@ -38,7 +38,7 @@ class OptionsService
 
   private static function get_default_options(): Options
   {
-    return new Options("", wp_generate_uuid4(), [], "p/{{PostShortcode}}/{{PostSlug}}", "u/{{PersonShortcode}}/{{PersonSlug}}", "", true, false, false, PASSLESYNC_DOMAIN_EXT, get_site_url());
+    return new Options("", wp_generate_uuid4(), [], "p/{{PostShortcode}}/{{PostSlug}}", "u/{{PersonShortcode}}/{{PersonSlug}}", "", true, false, false, false, PASSLESYNC_DOMAIN_EXT, get_site_url());
   }
 
   private static function get_resource_cpts()

--- a/class/Services/UpgradeService.php
+++ b/class/Services/UpgradeService.php
@@ -51,9 +51,18 @@ class UpgradeService
       return;
     }
 
-    $saved_options->post_permalink_template = $saved_options->post_permalink_prefix . "/{{PostShortcode}}/{{PostSlug}}";
-    $saved_options->person_permalink_template = $saved_options->person_permalink_prefix . "/{{PersonShortcode}}/{{PersonSlug}}";
+    if ($saved_options->post_permalink_prefix) {
+        $saved_options->post_permalink_template = $saved_options->post_permalink_prefix . "/{{PostShortcode}}/{{PostSlug}}";
+    } else {
+        $saved_options->post_permalink_template = "p/{{PostShortcode}}/{{PostSlug}}";
+    }
 
+    if ($saved_options->person_permalink_prefix) {
+        $saved_options->person_permalink_template = $saved_options->person_permalink_prefix . "/{{PersonShortcode}}/{{PersonSlug}}";
+    } else {
+        $saved_options->person_permalink_template = "u/{{PersonShortcode}}/{{PersonSlug}}";
+    }
+    
     unset($saved_options->post_permalink_prefix);
     unset($saved_options->person_permalink_prefix);
 

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -140,7 +140,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
     // Set post categories
-    if(isset($postarr_arrays["post_categories"])) {
+    if (isset($postarr_arrays["post_categories"])) {
       wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
     }
 

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -139,10 +139,15 @@ abstract class SyncHandlerBase extends ResourceClassBase
     // Insert the post
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
+    // Set post categories
+    if(isset($postarr_arrays["post_categories"])) {
+      wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
+    }
+
     // Add metadata for all arrays
     foreach ($postarr_arrays as $key => $value) {
       delete_post_meta($post_id, $key);
-
+      
       foreach ($value as $item) {
         add_post_meta($post_id, $key, $item);
       }

--- a/frontend/src/API/Types/Options.ts
+++ b/frontend/src/API/Types/Options.ts
@@ -8,6 +8,6 @@ export type Options = {
   simulateRemoteHosting: boolean;
   includePasslePostsOnHomePage: boolean;
   includePasslePostsOnTagPage: boolean;
-  includeTagsInCategories: boolean;
+  includeCategoriesFromPassleTagGroups: boolean;
   domainExt: string;
 };

--- a/frontend/src/API/Types/Options.ts
+++ b/frontend/src/API/Types/Options.ts
@@ -8,5 +8,6 @@ export type Options = {
   simulateRemoteHosting: boolean;
   includePasslePostsOnHomePage: boolean;
   includePasslePostsOnTagPage: boolean;
+  includeTagsInCategories: boolean;
   domainExt: string;
 };

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -40,8 +40,8 @@ const SyncSettings = () => {
   const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] = useState(
     options.includePasslePostsOnTagPage
   );
-  const [includeTagsInCategories, setIncludeTagsInCategories] = useState(
-    options.includeTagsInCategories
+  const [includeCategoriesFromPassleTagGroups, setIncludeCategoriesFromPassleTagGroups] = useState(
+    options.includeCategoriesFromPassleTagGroups
   );
 
   const saveSettings = async (finishLoadingCallback: () => void) => {
@@ -58,7 +58,7 @@ const SyncSettings = () => {
         simulateRemoteHosting,
         includePasslePostsOnHomePage,
         includePasslePostsOnTagPage,
-        includeTagsInCategories,
+        includeCategoriesFromPassleTagGroups,
       });
 
       if (options) {
@@ -180,10 +180,10 @@ const SyncSettings = () => {
             onChange={(e) => setIncludePasslePostsOnTagPage(e.target.checked)}
           />
           <BoolSettingsInput
-            label="Include Tags in Categories"
-            description="Whether to create tags inside categories defined in Passle. If unchecked, tags will be created as a flat list."
-            checked={includeTagsInCategories}
-            onChange={(e) => setIncludeTagsInCategories(e.target.checked)}
+            label="Include categories from Passle tag groups"
+            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts in them, based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default caterogy."
+            checked={includeCategoriesFromPassleTagGroups}
+            onChange={(e) => setIncludeCategoriesFromPassleTagGroups(e.target.checked)}
           />
         </tbody>
       </table>

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -181,7 +181,7 @@ const SyncSettings = () => {
           />
           <BoolSettingsInput
             label="Include categories from Passle tag groups"
-            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts in them, based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default caterogy."
+            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default category."
             checked={includeCategoriesFromPassleTagGroups}
             onChange={(e) => setIncludeCategoriesFromPassleTagGroups(e.target.checked)}
           />

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -11,11 +11,14 @@ import { updateSettings } from "_Services/SyncService";
 const SyncSettings = () => {
   const { setLoading } = useContext(PassleDataContext);
   const [notice, setNotice] = useState<NoticeType>(null);
-
   const { options, setOptions } = useOptions();
 
-  const [passleApiKey, setPassleApiKey] = useState(options.passleApiKey);
-  const [pluginApiKey, setPluginApiKey] = useState(options.pluginApiKey);
+  const [passleApiKey, setPassleApiKey] = useState(
+      options.passleApiKey
+  );
+  const [pluginApiKey, setPluginApiKey] = useState(
+      options.pluginApiKey
+  );
   const [passleShortcodes, setPassleShortcodes] = useState(
     options.passleShortcodes,
   );
@@ -31,10 +34,15 @@ const SyncSettings = () => {
   const [simulateRemoteHosting, setSimulateRemoteHosting] = useState(
     options.simulateRemoteHosting,
   );
-  const [includePasslePostsOnHomePage, setIncludePasslePostsOnHomePage] =
-    useState(options.includePasslePostsOnHomePage);
-  const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] =
-    useState(options.includePasslePostsOnTagPage);
+  const [includePasslePostsOnHomePage, setIncludePasslePostsOnHomePage] = useState(
+    options.includePasslePostsOnHomePage
+  );
+  const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] = useState(
+    options.includePasslePostsOnTagPage
+  );
+  const [includeTagsInCategories, setIncludeTagsInCategories] = useState(
+    options.includeTagsInCategories
+  );
 
   const saveSettings = async (finishLoadingCallback: () => void) => {
     setLoading(true);
@@ -50,6 +58,7 @@ const SyncSettings = () => {
         simulateRemoteHosting,
         includePasslePostsOnHomePage,
         includePasslePostsOnTagPage,
+        includeTagsInCategories,
       });
 
       if (options) {
@@ -169,6 +178,12 @@ const SyncSettings = () => {
             description="Whether or not to include Passle posts in the WordPress query that generates the tag page."
             checked={includePasslePostsOnTagPage}
             onChange={(e) => setIncludePasslePostsOnTagPage(e.target.checked)}
+          />
+          <BoolSettingsInput
+            label="Include Tags in Categories"
+            description="Whether to create tags inside categories defined in Passle. If unchecked, tags will be created as a flat list."
+            checked={includeTagsInCategories}
+            onChange={(e) => setIncludeTagsInCategories(e.target.checked)}
           />
         </tbody>
       </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passle-sync-wordpress",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "passle-sync-wordpress",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "cross-env": "^7.0.3",

--- a/passle-sync.php
+++ b/passle-sync.php
@@ -3,7 +3,7 @@
   Plugin Name: Passle Sync
   Plugin URI: https://github.com/passle/passle-sync-wordpress
   Description: This plugin will sync your Passle posts and authors into your WordPress instance.
-  Version: 1.2.1
+  Version: 2.0.0
   Author: Passle
   Author URI: https://www.passle.net
   License: MIT


### PR DESCRIPTION
A new setting has been added to the passle sync plugin settings that when checked, it will sync posts and create categories based off the tag groups that will be returned on each post - which, in turn depend on the tags on each post.

If posts contain tags that live inside tag groups, they will also be categorized in the correct WP category that is created for them.
Otherwise if this new setting is unchecked or there are no tag groups suitable for a post, the posts will be included in the default WP category.