### PR TITLE
Feature/lisi update custom taxonomy tests

### DIFF
--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,6 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
+      $params["includeTagsInCategories"]
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,7 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
-      $params["includeTagsInCategories"],
+      $params["includeCategoriesFromPassleTagGroups"],
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,7 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
-      $params["includeCategoriesFromPassleTagGroups"],
+      $params["includePassleTagGroups"],
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Controllers/SettingsController.php
+++ b/class/Controllers/SettingsController.php
@@ -32,7 +32,7 @@ class SettingsController extends ControllerBase
       $params["simulateRemoteHosting"],
       $params["includePasslePostsOnHomePage"],
       $params["includePasslePostsOnTagPage"],
-      $params["includeTagsInCategories"]
+      $params["includeTagsInCategories"],
       PASSLESYNC_DOMAIN_EXT,
       get_site_url(),
     );

--- a/class/Models/Admin/Options.php
+++ b/class/Models/Admin/Options.php
@@ -16,6 +16,7 @@ class Options implements JsonSerializable
   public bool $simulate_remote_hosting;
   public bool $include_passle_posts_on_home_page;
   public bool $include_passle_posts_on_tag_page;
+  public bool $include_tags_in_categories;
   public string $domain_ext;
   public string $site_url;
 
@@ -30,6 +31,7 @@ class Options implements JsonSerializable
     bool $simulate_remote_hosting,
     bool $include_passle_posts_on_home_page,
     bool $include_passle_posts_on_tag_page,
+    bool $include_tags_in_categories,
     string $domain_ext,
     string $site_url
   ) {
@@ -42,6 +44,7 @@ class Options implements JsonSerializable
     $this->simulate_remote_hosting = $simulate_remote_hosting;
     $this->include_passle_posts_on_home_page = $include_passle_posts_on_home_page;
     $this->include_passle_posts_on_tag_page = $include_passle_posts_on_tag_page;
+    $this->include_tags_in_categories = $include_tags_in_categories;
     $this->domain_ext = $domain_ext;
     $this->site_url = $site_url;
   }
@@ -58,6 +61,7 @@ class Options implements JsonSerializable
       "simulateRemoteHosting" => $this->simulate_remote_hosting,
       "includePasslePostsOnHomePage" => isset($this->include_passle_posts_on_home_page) ? $this->include_passle_posts_on_home_page : false,
       "includePasslePostsOnTagPage" => isset($this->include_passle_posts_on_tag_page) ? $this->include_passle_posts_on_tag_page : false,
+      "includeTagsInCategories" => isset($this->include_tags_in_categories) ? $this->include_tags_in_categories : false,
       "domainExt" => $this->domain_ext,
       "siteUrl" => $this->site_url,
     ];

--- a/class/Models/Admin/Options.php
+++ b/class/Models/Admin/Options.php
@@ -16,7 +16,7 @@ class Options implements JsonSerializable
   public bool $simulate_remote_hosting;
   public bool $include_passle_posts_on_home_page;
   public bool $include_passle_posts_on_tag_page;
-  public bool $include_tags_in_categories;
+  public bool $include_categories_from_passle_tag_groups;
   public string $domain_ext;
   public string $site_url;
 
@@ -31,7 +31,7 @@ class Options implements JsonSerializable
     bool $simulate_remote_hosting,
     bool $include_passle_posts_on_home_page,
     bool $include_passle_posts_on_tag_page,
-    bool $include_tags_in_categories,
+    bool $include_categories_from_passle_tag_groups,
     string $domain_ext,
     string $site_url
   ) {
@@ -44,7 +44,7 @@ class Options implements JsonSerializable
     $this->simulate_remote_hosting = $simulate_remote_hosting;
     $this->include_passle_posts_on_home_page = $include_passle_posts_on_home_page;
     $this->include_passle_posts_on_tag_page = $include_passle_posts_on_tag_page;
-    $this->include_tags_in_categories = $include_tags_in_categories;
+    $this->include_categories_from_passle_tag_groups = $include_categories_from_passle_tag_groups;
     $this->domain_ext = $domain_ext;
     $this->site_url = $site_url;
   }
@@ -61,7 +61,7 @@ class Options implements JsonSerializable
       "simulateRemoteHosting" => $this->simulate_remote_hosting,
       "includePasslePostsOnHomePage" => isset($this->include_passle_posts_on_home_page) ? $this->include_passle_posts_on_home_page : false,
       "includePasslePostsOnTagPage" => isset($this->include_passle_posts_on_tag_page) ? $this->include_passle_posts_on_tag_page : false,
-      "includeTagsInCategories" => isset($this->include_tags_in_categories) ? $this->include_tags_in_categories : false,
+      "includeCategoriesFromPassleTagGroups" => isset($this->include_categories_from_passle_tag_groups) ? $this->include_categories_from_passle_tag_groups : false,
       "domainExt" => $this->domain_ext,
       "siteUrl" => $this->site_url,
     ];

--- a/class/Models/Admin/Options.php
+++ b/class/Models/Admin/Options.php
@@ -16,7 +16,7 @@ class Options implements JsonSerializable
   public bool $simulate_remote_hosting;
   public bool $include_passle_posts_on_home_page;
   public bool $include_passle_posts_on_tag_page;
-  public bool $include_categories_from_passle_tag_groups;
+  public bool $include_passle_tag_groups;
   public string $domain_ext;
   public string $site_url;
 
@@ -31,7 +31,7 @@ class Options implements JsonSerializable
     bool $simulate_remote_hosting,
     bool $include_passle_posts_on_home_page,
     bool $include_passle_posts_on_tag_page,
-    bool $include_categories_from_passle_tag_groups,
+    bool $include_passle_tag_groups,
     string $domain_ext,
     string $site_url
   ) {
@@ -44,7 +44,7 @@ class Options implements JsonSerializable
     $this->simulate_remote_hosting = $simulate_remote_hosting;
     $this->include_passle_posts_on_home_page = $include_passle_posts_on_home_page;
     $this->include_passle_posts_on_tag_page = $include_passle_posts_on_tag_page;
-    $this->include_categories_from_passle_tag_groups = $include_categories_from_passle_tag_groups;
+    $this->include_passle_tag_groups = $include_passle_tag_groups;
     $this->domain_ext = $domain_ext;
     $this->site_url = $site_url;
   }
@@ -61,7 +61,7 @@ class Options implements JsonSerializable
       "simulateRemoteHosting" => $this->simulate_remote_hosting,
       "includePasslePostsOnHomePage" => isset($this->include_passle_posts_on_home_page) ? $this->include_passle_posts_on_home_page : false,
       "includePasslePostsOnTagPage" => isset($this->include_passle_posts_on_tag_page) ? $this->include_passle_posts_on_tag_page : false,
-      "includeCategoriesFromPassleTagGroups" => isset($this->include_categories_from_passle_tag_groups) ? $this->include_categories_from_passle_tag_groups : false,
+      "includePassleTagGroups" => isset($this->include_passle_tag_groups) ? $this->include_passle_tag_groups : false,
       "domainExt" => $this->domain_ext,
       "siteUrl" => $this->site_url,
     ];

--- a/class/PassleSync.php
+++ b/class/PassleSync.php
@@ -15,8 +15,12 @@ use Passle\PassleSync\Services\TemplateService;
 use Passle\PassleSync\Services\ThemeService;
 use Passle\PassleSync\Services\UpgradeService;
 
+use Passle\PassleSync\Services\Content\Passle\PassleTagGroupsContentService;
+
 class PassleSync
 {
+  private const TAG_GROUPS_CACHE_CLEAN_EVENT_NAME = "passle_sync_clear_tag_groups_cache_event";
+
   public static function initialize()
   {
     MenuService::init();
@@ -32,17 +36,45 @@ class PassleSync
     TemplateService::init();
     UpgradeService::init();
 
-    register_activation_hook(__FILE__, [static::class, "activate"]);
-    register_deactivation_hook(__FILE__, [static::class, "deactivate"]);
+    add_action(self::TAG_GROUPS_CACHE_CLEAN_EVENT_NAME, [static::class, "tag_groups_cache_cleanup"]);
   }
 
   public static function activate()
   {
     flush_rewrite_rules();
+    self::schedule_tag_groups_cache_cleanup();
   }
 
   public static function deactivate()
   {
     flush_rewrite_rules();
+    self::unschedule_tag_groups_cache_cleanup();
+  }
+
+  /*
+  *  The following code deals with scheduling tag groups cache cleanup, so when a new
+  *  tag group is created in Passle, at some point within the hour, it is also created in WP
+  *  following the init event. 
+  *  If a Resource class is created for passle tag groups, this code will need to be moved probably.
+  */ 
+  public static function schedule_tag_groups_cache_cleanup() 
+  {
+    if (!wp_next_scheduled(self::TAG_GROUPS_CACHE_CLEAN_EVENT_NAME)) {
+      wp_schedule_event(time(), "hourly", self::TAG_GROUPS_CACHE_CLEAN_EVENT_NAME);
+    }
+  }
+
+  public static function tag_groups_cache_cleanup() 
+  {
+     PassleTagGroupsContentService::overwrite_cache(array());
+  }
+
+  public static function unschedule_tag_groups_cache_cleanup()
+  {
+    $timestamp = wp_next_scheduled(self::TAG_GROUPS_CACHE_CLEAN_EVENT_NAME);
+    if ($timestamp) {
+        wp_unschedule_event($timestamp, self::TAG_GROUPS_CACHE_CLEAN_EVENT_NAME);
+    }
   }
 }
+

--- a/class/PassleSync.php
+++ b/class/PassleSync.php
@@ -22,9 +22,9 @@ class PassleSync
     MenuService::init();
     RouteRegistryService::init();
     CptRegistryService::init();
-    TaxonomyRegistryService::init();
     EmbedService::init();
     OptionsService::init();
+    TaxonomyRegistryService::init();
     SchedulerService::init();
     ConfigService::init();
     ThemeService::init();

--- a/class/PassleSync.php
+++ b/class/PassleSync.php
@@ -3,6 +3,7 @@
 namespace Passle\PassleSync;
 
 use Passle\PassleSync\Services\CptRegistryService;
+use Passle\PassleSync\Services\TaxonomyRegistryService;
 use Passle\PassleSync\Services\EmbedService;
 use Passle\PassleSync\Services\MenuService;
 use Passle\PassleSync\Services\OptionsService;
@@ -21,6 +22,7 @@ class PassleSync
     MenuService::init();
     RouteRegistryService::init();
     CptRegistryService::init();
+    TaxonomyRegistryService::init();
     EmbedService::init();
     OptionsService::init();
     SchedulerService::init();

--- a/class/PostTypes/CptBase.php
+++ b/class/PostTypes/CptBase.php
@@ -57,7 +57,6 @@ abstract class CptBase extends ResourceClassBase
       ],
       "hierarchical" => false,
       "supports" => ["title", "custom-fields"],
-      "taxonomies" => ["post_tag"],
       "has_archive" => true,
       "rewrite" => false,
       "query_var" => true,

--- a/class/PostTypes/PasslePostCpt.php
+++ b/class/PostTypes/PasslePostCpt.php
@@ -11,10 +11,17 @@ class PasslePostCpt extends CptBase
 
   protected static function get_cpt_args(): array
   {
-    return [
-      "menu_icon" => "dashicons-admin-post",
-      "taxonomies" => ["tag_group", "category", "post_tag"],
+    $args = [
+       "menu_icon" => "dashicons-admin-post"
     ];
+
+    if (OptionsService::get()->include_passle_tag_groups) {
+        $args["taxonomies"] = ["tag_group", "post_tag"];
+    } else {
+        $args["taxonomies"] = ["post_tag"];
+    }
+
+    return $args;
   }
 
   protected static function get_permalink_template(): string

--- a/class/PostTypes/PasslePostCpt.php
+++ b/class/PostTypes/PasslePostCpt.php
@@ -13,7 +13,7 @@ class PasslePostCpt extends CptBase
   {
     return [
       "menu_icon" => "dashicons-admin-post",
-      "taxonomies" => ["post_tag"],
+      "taxonomies" => ["category", "post_tag"],
     ];
   }
 

--- a/class/PostTypes/PasslePostCpt.php
+++ b/class/PostTypes/PasslePostCpt.php
@@ -13,7 +13,7 @@ class PasslePostCpt extends CptBase
   {
     return [
       "menu_icon" => "dashicons-admin-post",
-      "taxonomies" => ["category", "post_tag"],
+      "taxonomies" => ["tag_group", "category", "post_tag"],
     ];
   }
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -57,7 +57,9 @@ abstract class PassleContentServiceBase extends ResourceClassBase
 
   public static function fetch_all()
   {
-    $passle_shortcodes = OptionsService::get()->passle_shortcodes;
+    $options = OptionsService::get();
+
+    $passle_shortcodes = $options->passle_shortcodes;
 
     /** @var array[] $results */
     $results = array_map(fn ($passle_shortcode) => static::fetch_all_by_passle($passle_shortcode), $passle_shortcodes);
@@ -86,14 +88,23 @@ abstract class PassleContentServiceBase extends ResourceClassBase
   public static function fetch_all_by_passle(string $passle_shortcode)
   {
     $resource = static::get_resource_instance();
+    $options = OptionsService::get();
+
+    $path = "passlesync/{$resource->name_plural}";
+    
+    $parameters = array(
+      "PassleShortcode" => $passle_shortcode,
+      "ItemsPerPage" => "100"
+    );
+
+    if ($options->include_tags_in_categories) {
+        $parameters["IncludeTagGroups"] = "true";
+    }
 
     $url = (new UrlFactory())
-      ->path("passlesync/{$resource->name_plural}")
-      ->parameters([
-        "PassleShortcode" => $passle_shortcode,
-        "ItemsPerPage" => "100"
-      ])
-      ->build();
+        ->path($path)
+        ->parameters($parameters)
+        ->build();
 
     $responses = static::get_all_paginated($url);
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -97,7 +97,7 @@ abstract class PassleContentServiceBase extends ResourceClassBase
       "ItemsPerPage" => "100"
     );
 
-    if ($options->include_categories_from_passle_tag_groups) {
+    if ($options->include_passle_tag_groups) {
         $parameters["IncludeTagGroups"] = "true";
     }
 
@@ -131,7 +131,7 @@ abstract class PassleContentServiceBase extends ResourceClassBase
       $resource->get_api_parameter_shortcode_name() => join(",", $entity_shortcodes)
     ];
 
-    if ($options->include_categories_from_passle_tag_groups) {
+    if ($options->include_passle_tag_groups) {
         $params["IncludeTagGroups"] = "true";
     }
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -97,7 +97,7 @@ abstract class PassleContentServiceBase extends ResourceClassBase
       "ItemsPerPage" => "100"
     );
 
-    if ($options->include_tags_in_categories) {
+    if ($options->include_categories_from_passle_tag_groups) {
         $parameters["IncludeTagGroups"] = "true";
     }
 
@@ -125,10 +125,15 @@ abstract class PassleContentServiceBase extends ResourceClassBase
   public static function fetch_multiple_by_shortcode(array $entity_shortcodes)
   {
     $resource = static::get_resource_instance();
+    $options = OptionsService::get();
 
     $params = [
       $resource->get_api_parameter_shortcode_name() => join(",", $entity_shortcodes)
     ];
+
+    if ($options->include_categories_from_passle_tag_groups) {
+        $params["IncludeTagGroups"] = "true";
+    }
 
     $factory = new UrlFactory();
     $url = $factory

--- a/class/Services/Content/Passle/PassleTagGroupsContentService.php
+++ b/class/Services/Content/Passle/PassleTagGroupsContentService.php
@@ -7,6 +7,28 @@ use Passle\PassleSync\Services\OptionsService;
 
 class PassleTagGroupsContentService extends PassleContentServiceBase 
 {
+  private const TAG_GROUPS_CACHE_KEY = "passle_sync_tag_groups_cache";
+  
+  public static function get_cache()
+  {
+    $items = get_option(self::TAG_GROUPS_CACHE_KEY);
+
+    if (gettype($items) != "array" || count($items) == 0 || reset($items) == null) {
+      $items = self::fetch_tag_groups();
+    }
+
+    return $items;
+  }
+
+  public static function overwrite_cache(array $data)
+  {
+    $success = update_option(self::TAG_GROUPS_CACHE_KEY, $data, false);
+
+    if (!$success) {
+      error_log('Failed to overwrite cache: ' . self::TAG_GROUPS_CACHE_KEY);
+    }
+  }
+
   public static function fetch_tag_groups() 
   {
     $options = OptionsService::get();
@@ -14,6 +36,8 @@ class PassleTagGroupsContentService extends PassleContentServiceBase
 	$passle_shortcodes = $options->passle_shortcodes;
 
 	$results = array_map(fn ($passle_shortcode) => static::fetch_tag_groups_by_passle($passle_shortcode), $passle_shortcodes);
+
+    self::overwrite_cache($results);
 
     return $results;
   }

--- a/class/Services/Content/Passle/PassleTagGroupsContentService.php
+++ b/class/Services/Content/Passle/PassleTagGroupsContentService.php
@@ -1,0 +1,30 @@
+<?php 
+
+namespace Passle\PassleSync\Services\Content\Passle;
+
+use Passle\PassleSync\Utils\UrlFactory;
+use Passle\PassleSync\Services\OptionsService;
+
+class PassleTagGroupsContentService extends PassleContentServiceBase 
+{
+  public static function fetch_tag_groups() 
+  {
+    $options = OptionsService::get();
+
+	$passle_shortcodes = $options->passle_shortcodes;
+
+	$results = array_map(fn ($passle_shortcode) => static::fetch_tag_groups_by_passle($passle_shortcode), $passle_shortcodes);
+
+    return $results;
+  }
+
+  public static function fetch_tag_groups_by_passle($passle_shortcode) {
+    $path = "taggroups/$passle_shortcode";
+  
+    $url = (new UrlFactory())
+      ->path($path)
+	  ->build();
+
+     return static::get($url);
+  }
+}

--- a/class/Services/OptionsService.php
+++ b/class/Services/OptionsService.php
@@ -38,7 +38,7 @@ class OptionsService
 
   private static function get_default_options(): Options
   {
-    return new Options("", wp_generate_uuid4(), [], "p/{{PostShortcode}}/{{PostSlug}}", "u/{{PersonShortcode}}/{{PersonSlug}}", "", true, false, false, PASSLESYNC_DOMAIN_EXT, get_site_url());
+    return new Options("", wp_generate_uuid4(), [], "p/{{PostShortcode}}/{{PostSlug}}", "u/{{PersonShortcode}}/{{PersonSlug}}", "", true, false, false, false, PASSLESYNC_DOMAIN_EXT, get_site_url());
   }
 
   private static function get_resource_cpts()

--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -17,7 +17,7 @@ class TaxonomyRegistryService
     public static function create_taxonomies() 
     {
         $tag_groups_response = PassleTagGroupsContentService::fetch_tag_groups();
-        if (isempty($tag_groups_response) || !isset($tag_groups_response[0]) || !isset($tag_groups_response[0]["TagGroups"])) {
+        if (empty($tag_groups_response) || !isset($tag_groups_response[0]) || !isset($tag_groups_response[0]["TagGroups"])) {
             return;
         }
         $tag_groups = $tag_groups_response[0]["TagGroups"];

--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -46,14 +46,14 @@ class TaxonomyRegistryService
                 if (!$term_exists) {
                     $term = wp_insert_term(
                         $tag,
-                        $slug,
+                        $taxonomy_name,
                         array(
                         "parent" => 0
                         )
                     );
                 
                     if (is_wp_error($term)) {
-                        error_log("Error creating term: " . $term->get_error_message() . PHP_EOL); 
+                        error_log("Error creating term: $term " . $term->get_error_message() . PHP_EOL); 
                     }
                 }
             }

--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -7,6 +7,7 @@ class TaxonomyRegistryService
     public static function init() 
     {   
         add_action("init", [static::class, "create_taxonomy"]);
+        add_filter('term_row_actions', 'disable_taxonomy_term_editing', 10, 3);
     }
 
     public static function create_taxonomy() 
@@ -20,7 +21,7 @@ class TaxonomyRegistryService
             "update_item" => "Update Passle Tag Group",
             "add_new_item" => "Add new Passle Tag Group",
             "new_item_name" => "New Passle Tag Group name",
-            "menu_name" => "Passle Tag Group",
+            "menu_name" => "Passle Tag Groups",
             "not_found" => "No Passle Tag Groups Found"
         );
 
@@ -31,9 +32,18 @@ class TaxonomyRegistryService
             "show_admin_column" => true,
             "query_var" => true,
             "meta_box_cb" => null,
-            "rewrite" => array("slug" => "tag_group")
+            "rewrite" => array("slug" => PASSLESYNC_TAG_GROUP_TAXONOMY)
         );
 
-        register_taxonomy("tag_group", array(PASSLESYNC_POST_TYPE), $args);
+        register_taxonomy(PASSLESYNC_TAG_GROUP_TAXONOMY, array(PASSLESYNC_POST_TYPE), $args);
+    }
+
+    public static function disable_taxonomy_term_editing($actions, $taxonomy, $tag) 
+    {
+        if ($taxonomy === PASSLESYNC_TAG_GROUP_TAXONOMY) {
+            unset($actions["edit"]);
+            unset($actions["inline hide-if-no-js"]);
+        }
+        return $actions;
     }
 }

--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -6,17 +6,19 @@ use Passle\PassleSync\Services\Content\Passle\PassleTagGroupsContentService;
 
 class TaxonomyRegistryService 
 {
-    public static function init() {
+    public static function init() 
+    {
         add_action('init', [static::class, "create_taxonomies"]);
     }
 
-    private static function get_taxonomy_slug($name) {
+    private static function get_taxonomy_slug($name) 
+    {
         return str_replace(' ', '_', strtolower($name));
     }
 
     public static function create_taxonomies() 
     {
-        $tag_groups_response = PassleTagGroupsContentService::fetch_tag_groups();
+        $tag_groups_response = PassleTagGroupsContentService::get_cache();
         if (empty($tag_groups_response) || !isset($tag_groups_response[0]) || !isset($tag_groups_response[0]["TagGroups"])) {
             return;
         }

--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -1,0 +1,39 @@
+<?php 
+
+namespace Passle\PassleSync\Services;
+
+class TaxonomyRegistryService 
+{
+    public static function init() 
+    {   
+        add_action("init", [static::class, "create_taxonomy"]);
+    }
+
+    public static function create_taxonomy() 
+    {
+        $labels = array(
+            "name" => "Passle Tag Groups",
+            "singular_name" => "Passle Tag Group",
+            "search_items" => "Search Passle Tag Groups",
+            "all_items" => "All Passle Tag Groups",
+            "edit_item" => "Edit Passle Tag Group",
+            "update_item" => "Update Passle Tag Group",
+            "add_new_item" => "Add new Passle Tag Group",
+            "new_item_name" => "New Passle Tag Group name",
+            "menu_name" => "Passle Tag Group",
+            "not_found" => "No Passle Tag Groups Found"
+        );
+
+        $args = array(
+            "hierarchical" => false,
+            "labels" => $labels,
+            "show_ui" => true,
+            "show_admin_column" => true,
+            "query_var" => true,
+            "meta_box_cb" => null,
+            "rewrite" => array("slug" => "tag_group")
+        );
+
+        register_taxonomy("tag_group", array(PASSLESYNC_POST_TYPE), $args);
+    }
+}

--- a/class/Services/TemplateService.php
+++ b/class/Services/TemplateService.php
@@ -20,7 +20,7 @@ class TemplateService
       $is_passle_preview = true;
       $shortcode = get_query_var("passle_preview");
       $post = PasslePostsContentService::fetch_preview($shortcode);
-      if ($post == null) {
+      if (is_null($post)) {
         self::redirect_404();
         return;
       }
@@ -28,7 +28,7 @@ class TemplateService
       return get_query_template("single-passle-post");
     } else if (get_query_var("post_type") == "passle-post") {
       $is_passle_preview = false;
-      if ($post == null) {
+      if (is_null($post)) {
         self::redirect_404();
         return;
       }

--- a/class/Services/TemplateService.php
+++ b/class/Services/TemplateService.php
@@ -20,13 +20,30 @@ class TemplateService
       $is_passle_preview = true;
       $shortcode = get_query_var("passle_preview");
       $post = PasslePostsContentService::fetch_preview($shortcode);
+      if ($post == null) {
+        self::redirect_404();
+        return;
+      }
       $passle_post = new PasslePost($post);
       return get_query_template("single-passle-post");
     } else if (get_query_var("post_type") == "passle-post") {
       $is_passle_preview = false;
+      if ($post == null) {
+        self::redirect_404();
+        return;
+      }
       $passle_post = new PasslePost($post);
     }
 
     return $original_template;
+  }
+
+  private static function redirect_404() 
+  {  
+	status_header(404);
+
+    include(get_404_template());
+
+    exit();
   }
 }

--- a/class/Services/UpgradeService.php
+++ b/class/Services/UpgradeService.php
@@ -51,9 +51,18 @@ class UpgradeService
       return;
     }
 
-    $saved_options->post_permalink_template = $saved_options->post_permalink_prefix . "/{{PostShortcode}}/{{PostSlug}}";
-    $saved_options->person_permalink_template = $saved_options->person_permalink_prefix . "/{{PersonShortcode}}/{{PersonSlug}}";
+    if ($saved_options->post_permalink_prefix) {
+        $saved_options->post_permalink_template = $saved_options->post_permalink_prefix . "/{{PostShortcode}}/{{PostSlug}}";
+    } else {
+        $saved_options->post_permalink_template = "p/{{PostShortcode}}/{{PostSlug}}";
+    }
 
+    if ($saved_options->person_permalink_prefix) {
+        $saved_options->person_permalink_template = $saved_options->person_permalink_prefix . "/{{PersonShortcode}}/{{PersonSlug}}";
+    } else {
+        $saved_options->person_permalink_template = "u/{{PersonShortcode}}/{{PersonSlug}}";
+    }
+    
     unset($saved_options->post_permalink_prefix);
     unset($saved_options->person_permalink_prefix);
 

--- a/class/SyncHandlers/PostHandler.php
+++ b/class/SyncHandlers/PostHandler.php
@@ -46,6 +46,7 @@ class PostHandler extends SyncHandlerBase
         "post_is_repost" => $data["IsRepost"],
         "post_estimated_read_time" => $data["EstimatedReadTimeInSeconds"],
         "post_tags" => $data["Tags"],
+        "post_tag_group_tags" => $data["Tags"],
         "post_image_url" => $data["ImageUrl"],
         "post_featured_item_html" => $data["FeaturedItemHtml"],
         "post_featured_item_position" => $data["FeaturedItemPosition"],

--- a/class/SyncHandlers/PostHandler.php
+++ b/class/SyncHandlers/PostHandler.php
@@ -102,43 +102,4 @@ class PostHandler extends SyncHandlerBase
       "screen_name" => $tweet["ScreenName"],
     ], $tweets);
   }
-
-  private static function map_tag_groups_to_custom_taxonomy(array $tag_groups)
-  {
-      $term_ids = array();
-
-      if (taxonomy_exists(PASSLESYNC_TAG_GROUP_TAXONOMY)) {
-
-        foreach($tag_groups as $tag_group) {
-
-            $term_name = $tag_group["Name"];
-
-            // Check if the term already exists 
-            $term_exists = term_exists($term_name, PASSLESYNC_TAG_GROUP_TAXONOMY);
-
-            if (!$term_exists) {
-                $term = wp_insert_term(
-                    $term_name,
-                    PASSLESYNC_TAG_GROUP_TAXONOMY,
-                    array(
-                      "parent" => 0
-                    )
-                );
-                
-                if (is_wp_error($term)) {
-                    error_log("Error creating term: " . $term->get_error_message() . PHP_EOL); 
-                }
-            } 
-            else {
-                $term = get_term_by("name", $term_name, PASSLESYNC_TAG_GROUP_TAXONOMY);
-            }
-
-            if ($term) {
-                $term_ids[] = $term->term_id;
-            }
-        }
-      }
-
-      return $term_ids;
-  }
 }

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -149,7 +149,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
             foreach($postarr_arrays["post_tag_group_tags"] as $tag) {
                 $term = get_term_by("name", $tag, $taxonomy);
                 if($term != null && $term->name && $term->taxonomy) {
-                    wp_set_object_terms($post_id, $term->name, $term->taxonomy);
+                    wp_set_object_terms($post_id, $term->name, $term->taxonomy, true);
                 }
             }
         }

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -140,7 +140,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
     // Set post categories
-    if(isset($postarr_arrays["post_categories"])) {
+    if (isset($postarr_arrays["post_categories"])) {
       wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
     }
 

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -144,6 +144,11 @@ abstract class SyncHandlerBase extends ResourceClassBase
       wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
     }
 
+    // Set post tag groups
+    if (isset($postarr_arrays["post_tag_groups"]) && !empty($postarr_arrays["post_tag_groups"])) {
+        wp_set_object_terms($post_id, $postarr_arrays["post_tag_groups"], "tag_group", false);
+    }
+
     // Add metadata for all arrays
     foreach ($postarr_arrays as $key => $value) {
       delete_post_meta($post_id, $key);

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -144,7 +144,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
 
     // Set post taxonomy terms based on tags
     if (!empty($postarr_arrays["post_tag_group_tags"]) && $options->include_passle_tag_groups) {
-        $taxonomies = get_object_taxonomies(PASSLESYNC_POST_TYPE);
+        $taxonomies = get_taxonomies(array("object_type" => array(PASSLESYNC_POST_TYPE), "public" => true, "_builtin" => false));
         foreach ($taxonomies as $taxonomy) {
             foreach($postarr_arrays["post_tag_group_tags"] as $tag) {
                 $term = get_term_by("name", $tag, $taxonomy);

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -4,6 +4,7 @@ namespace Passle\PassleSync\SyncHandlers;
 
 use Passle\PassleSync\Utils\ResourceClassBase;
 use Passle\PassleSync\Utils\Utils;
+use Passle\PassleSync\Services\OptionsService;
 
 abstract class SyncHandlerBase extends ResourceClassBase
 {
@@ -123,6 +124,8 @@ abstract class SyncHandlerBase extends ResourceClassBase
 
   protected static function insert_post(array $postarr, $wp_error = \false, $fire_after_hooks = \true)
   {
+    $options = OptionsService::get();
+
     if (empty($postarr["meta_input"])) {
       return wp_insert_post($postarr, $wp_error, $fire_after_hooks);
     }
@@ -139,9 +142,17 @@ abstract class SyncHandlerBase extends ResourceClassBase
     // Insert the post
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
-    // Set post tag groups
-    if (isset($postarr_arrays["post_tag_groups"]) && !empty($postarr_arrays["post_tag_groups"])) {
-        wp_set_object_terms($post_id, $postarr_arrays["post_tag_groups"], PASSLESYNC_TAG_GROUP_TAXONOMY, false);
+    // Set post taxonomy terms based on tags
+    if (!empty($postarr_arrays["post_tags"]) && $options->include_passle_tag_groups) {
+        $taxonomies = get_object_taxonomies(PASSLESYNC_POST_TYPE);
+        foreach ($taxonomies as $taxonomy) {
+            foreach($postarr_arrays["post_tags"] as $tag) {
+                $term = get_term_by('name', $tag, $taxonomy);
+                if($term != null && $term->name && $term->taxonomy) {
+                    wp_set_object_terms($post_id, $term->name, $term->taxonomy);
+                }
+            }
+        }
     }
 
     // Add metadata for all arrays

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -147,7 +147,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
         $taxonomies = get_object_taxonomies(PASSLESYNC_POST_TYPE);
         foreach ($taxonomies as $taxonomy) {
             foreach($postarr_arrays["post_tags"] as $tag) {
-                $term = get_term_by('name', $tag, $taxonomy);
+                $term = get_term_by("name", $tag, $taxonomy);
                 if($term != null && $term->name && $term->taxonomy) {
                     wp_set_object_terms($post_id, $term->name, $term->taxonomy);
                 }

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -139,10 +139,15 @@ abstract class SyncHandlerBase extends ResourceClassBase
     // Insert the post
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
+    // Set post categories
+    if(isset($postarr_arrays["post_categories"])) {
+      wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
+    }
+
     // Add metadata for all arrays
     foreach ($postarr_arrays as $key => $value) {
       delete_post_meta($post_id, $key);
-
+      
       foreach ($value as $item) {
         add_post_meta($post_id, $key, $item);
       }

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -139,14 +139,9 @@ abstract class SyncHandlerBase extends ResourceClassBase
     // Insert the post
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
-    // Set post categories
-    if (isset($postarr_arrays["post_categories"])) {
-      wp_set_post_categories($post_id, $postarr_arrays["post_categories"]);
-    }
-
     // Set post tag groups
     if (isset($postarr_arrays["post_tag_groups"]) && !empty($postarr_arrays["post_tag_groups"])) {
-        wp_set_object_terms($post_id, $postarr_arrays["post_tag_groups"], "tag_group", false);
+        wp_set_object_terms($post_id, $postarr_arrays["post_tag_groups"], PASSLESYNC_TAG_GROUP_TAXONOMY, false);
     }
 
     // Add metadata for all arrays

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -143,10 +143,10 @@ abstract class SyncHandlerBase extends ResourceClassBase
     $post_id = wp_insert_post($postarr, $wp_error, $fire_after_hooks);
 
     // Set post taxonomy terms based on tags
-    if (!empty($postarr_arrays["post_tags"]) && $options->include_passle_tag_groups) {
+    if (!empty($postarr_arrays["post_tag_group_tags"]) && $options->include_passle_tag_groups) {
         $taxonomies = get_object_taxonomies(PASSLESYNC_POST_TYPE);
         foreach ($taxonomies as $taxonomy) {
-            foreach($postarr_arrays["post_tags"] as $tag) {
+            foreach($postarr_arrays["post_tag_group_tags"] as $tag) {
                 $term = get_term_by("name", $tag, $taxonomy);
                 if($term != null && $term->name && $term->taxonomy) {
                     wp_set_object_terms($post_id, $term->name, $term->taxonomy);
@@ -154,6 +154,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
             }
         }
     }
+    unset($postarr_arrays["post_tag_group_tags"]);
 
     // Add metadata for all arrays
     foreach ($postarr_arrays as $key => $value) {

--- a/constants.php
+++ b/constants.php
@@ -18,7 +18,6 @@ passle_constants("POSTS_CACHE", "passlesync_posts_cache");
 passle_constants("AUTHORS_CACHE", "passlesync_authors_cache");
 passle_constants("POST_TYPE", "passle-post");
 passle_constants("AUTHOR_TYPE", "passle-author");
-passle_constants("TAG_GROUP_TAXONOMY", "tag_group");
 passle_constants("CLIENT_API_BASE", "clientwebapi.passle." . PASSLESYNC_DOMAIN_EXT . "/api/v2");
 passle_constants("DEFAULT_AVATAR_URL", "https://images.passle.net/200x200/assets/images/no_avatar.png");
 passle_constants("ASSET_MANIFEST", plugin_dir_path(__FILE__) . "/frontend/dist/asset-manifest.json");

--- a/constants.php
+++ b/constants.php
@@ -18,6 +18,7 @@ passle_constants("POSTS_CACHE", "passlesync_posts_cache");
 passle_constants("AUTHORS_CACHE", "passlesync_authors_cache");
 passle_constants("POST_TYPE", "passle-post");
 passle_constants("AUTHOR_TYPE", "passle-author");
+passle_constants("TAG_GROUP_TAXONOMY", "tag_group");
 passle_constants("CLIENT_API_BASE", "clientwebapi.passle." . PASSLESYNC_DOMAIN_EXT . "/api/v2");
 passle_constants("DEFAULT_AVATAR_URL", "https://images.passle.net/200x200/assets/images/no_avatar.png");
 passle_constants("ASSET_MANIFEST", plugin_dir_path(__FILE__) . "/frontend/dist/asset-manifest.json");

--- a/frontend/src/API/Types/Options.ts
+++ b/frontend/src/API/Types/Options.ts
@@ -8,6 +8,6 @@ export type Options = {
   simulateRemoteHosting: boolean;
   includePasslePostsOnHomePage: boolean;
   includePasslePostsOnTagPage: boolean;
-  includeTagsInCategories: boolean;
+  includeCategoriesFromPassleTagGroups: boolean;
   domainExt: string;
 };

--- a/frontend/src/API/Types/Options.ts
+++ b/frontend/src/API/Types/Options.ts
@@ -8,5 +8,6 @@ export type Options = {
   simulateRemoteHosting: boolean;
   includePasslePostsOnHomePage: boolean;
   includePasslePostsOnTagPage: boolean;
+  includeTagsInCategories: boolean;
   domainExt: string;
 };

--- a/frontend/src/API/Types/Options.ts
+++ b/frontend/src/API/Types/Options.ts
@@ -8,6 +8,6 @@ export type Options = {
   simulateRemoteHosting: boolean;
   includePasslePostsOnHomePage: boolean;
   includePasslePostsOnTagPage: boolean;
-  includeCategoriesFromPassleTagGroups: boolean;
+  includePassleTagGroups: boolean;
   domainExt: string;
 };

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -47,6 +47,8 @@ const SyncSettings = () => {
   const saveSettings = async (finishLoadingCallback: () => void) => {
     setLoading(true);
 
+    let includePassleTagGroupsInitialValue = options.includePassleTagGroups;
+
     try {
       const options = await updateSettings({
         passleApiKey,
@@ -68,6 +70,12 @@ const SyncSettings = () => {
         });
 
         setOptions(options);
+
+        // We need to reload the page so the plugin re-initializes when this option changes
+        // and settings are subsequently saved
+        if (includePassleTagGroupsInitialValue != includePassleTagGroups) {
+          setTimeout(() => { window.location.reload(); }, 1000);
+        }
       } else {
         setNotice({
           content: "Failed to update settings.",

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -40,8 +40,8 @@ const SyncSettings = () => {
   const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] = useState(
     options.includePasslePostsOnTagPage
   );
-  const [includeTagsInCategories, setIncludeTagsInCategories] = useState(
-    options.includeTagsInCategories
+  const [includeCategoriesFromPassleTagGroups, setIncludeCategoriesFromPassleTagGroups] = useState(
+    options.includeCategoriesFromPassleTagGroups
   );
 
   const saveSettings = async (finishLoadingCallback: () => void) => {
@@ -58,7 +58,7 @@ const SyncSettings = () => {
         simulateRemoteHosting,
         includePasslePostsOnHomePage,
         includePasslePostsOnTagPage,
-        includeTagsInCategories,
+        includeCategoriesFromPassleTagGroups,
       });
 
       if (options) {
@@ -180,10 +180,10 @@ const SyncSettings = () => {
             onChange={(e) => setIncludePasslePostsOnTagPage(e.target.checked)}
           />
           <BoolSettingsInput
-            label="Include Tags in Categories"
-            description="Whether to create tags inside categories defined in Passle. If unchecked, tags will be created as a flat list."
-            checked={includeTagsInCategories}
-            onChange={(e) => setIncludeTagsInCategories(e.target.checked)}
+            label="Include categories from Passle tag groups"
+            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts in them, based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default caterogy."
+            checked={includeCategoriesFromPassleTagGroups}
+            onChange={(e) => setIncludeCategoriesFromPassleTagGroups(e.target.checked)}
           />
         </tbody>
       </table>

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -40,8 +40,8 @@ const SyncSettings = () => {
   const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] = useState(
     options.includePasslePostsOnTagPage
   );
-  const [includeCategoriesFromPassleTagGroups, setIncludeCategoriesFromPassleTagGroups] = useState(
-    options.includeCategoriesFromPassleTagGroups
+  const [includePassleTagGroups, setIncludePassleTagGroups] = useState(
+    options.includePassleTagGroups
   );
 
   const saveSettings = async (finishLoadingCallback: () => void) => {
@@ -58,7 +58,7 @@ const SyncSettings = () => {
         simulateRemoteHosting,
         includePasslePostsOnHomePage,
         includePasslePostsOnTagPage,
-        includeCategoriesFromPassleTagGroups,
+        includePassleTagGroups,
       });
 
       if (options) {
@@ -180,10 +180,10 @@ const SyncSettings = () => {
             onChange={(e) => setIncludePasslePostsOnTagPage(e.target.checked)}
           />
           <BoolSettingsInput
-            label="Include categories from Passle tag groups"
-            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default category."
-            checked={includeCategoriesFromPassleTagGroups}
-            onChange={(e) => setIncludeCategoriesFromPassleTagGroups(e.target.checked)}
+            label="Include Passle tag groups"
+            description="Whether to create a custom taxonomy from tag groups defined in Passle. If checked, syncing will create taxonomy terms that correspond to tag groups and include set it on Passle posts based on the tags on each post."
+            checked={includePassleTagGroups}
+            onChange={(e) => setIncludePassleTagGroups(e.target.checked)}
           />
         </tbody>
       </table>

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -181,7 +181,7 @@ const SyncSettings = () => {
           />
           <BoolSettingsInput
             label="Include categories from Passle tag groups"
-            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts in them, based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default caterogy."
+            description="Whether to create categories from tag groups defined in Passle. If checked, syncing will create categories that correspond to tag groups and include Passle posts based on the tags on each post. If no tag groups are defined in Passle or this option is unchecked, all Passle posts will be included in the default category."
             checked={includeCategoriesFromPassleTagGroups}
             onChange={(e) => setIncludeCategoriesFromPassleTagGroups(e.target.checked)}
           />

--- a/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
+++ b/frontend/src/Components/Organisms/SyncSettings/SyncSettings.tsx
@@ -11,11 +11,14 @@ import { updateSettings } from "_Services/SyncService";
 const SyncSettings = () => {
   const { setLoading } = useContext(PassleDataContext);
   const [notice, setNotice] = useState<NoticeType>(null);
-
   const { options, setOptions } = useOptions();
 
-  const [passleApiKey, setPassleApiKey] = useState(options.passleApiKey);
-  const [pluginApiKey, setPluginApiKey] = useState(options.pluginApiKey);
+  const [passleApiKey, setPassleApiKey] = useState(
+      options.passleApiKey
+  );
+  const [pluginApiKey, setPluginApiKey] = useState(
+      options.pluginApiKey
+  );
   const [passleShortcodes, setPassleShortcodes] = useState(
     options.passleShortcodes,
   );
@@ -31,10 +34,15 @@ const SyncSettings = () => {
   const [simulateRemoteHosting, setSimulateRemoteHosting] = useState(
     options.simulateRemoteHosting,
   );
-  const [includePasslePostsOnHomePage, setIncludePasslePostsOnHomePage] =
-    useState(options.includePasslePostsOnHomePage);
-  const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] =
-    useState(options.includePasslePostsOnTagPage);
+  const [includePasslePostsOnHomePage, setIncludePasslePostsOnHomePage] = useState(
+    options.includePasslePostsOnHomePage
+  );
+  const [includePasslePostsOnTagPage, setIncludePasslePostsOnTagPage] = useState(
+    options.includePasslePostsOnTagPage
+  );
+  const [includeTagsInCategories, setIncludeTagsInCategories] = useState(
+    options.includeTagsInCategories
+  );
 
   const saveSettings = async (finishLoadingCallback: () => void) => {
     setLoading(true);
@@ -50,6 +58,7 @@ const SyncSettings = () => {
         simulateRemoteHosting,
         includePasslePostsOnHomePage,
         includePasslePostsOnTagPage,
+        includeTagsInCategories,
       });
 
       if (options) {
@@ -169,6 +178,12 @@ const SyncSettings = () => {
             description="Whether or not to include Passle posts in the WordPress query that generates the tag page."
             checked={includePasslePostsOnTagPage}
             onChange={(e) => setIncludePasslePostsOnTagPage(e.target.checked)}
+          />
+          <BoolSettingsInput
+            label="Include Tags in Categories"
+            description="Whether to create tags inside categories defined in Passle. If unchecked, tags will be created as a flat list."
+            checked={includeTagsInCategories}
+            onChange={(e) => setIncludeTagsInCategories(e.target.checked)}
           />
         </tbody>
       </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passle-sync-wordpress",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "passle-sync-wordpress",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "cross-env": "^7.0.3",

--- a/passle-sync.php
+++ b/passle-sync.php
@@ -3,7 +3,7 @@
   Plugin Name: Passle Sync
   Plugin URI: https://github.com/passle/passle-sync-wordpress
   Description: This plugin will sync your Passle posts and authors into your WordPress instance.
-  Version: 1.2.1
+  Version: 2.0.0
   Author: Passle
   Author URI: https://www.passle.net
   License: MIT

--- a/passle-sync.php
+++ b/passle-sync.php
@@ -26,3 +26,18 @@ require_once $passle_base_path . '/initialize.php';
 foreach (glob($passle_base_path . "/class/SyncHandlers/Handlers/*.php") as $filename) {
   require_once $filename;
 }
+
+require_once $passle_base_path . "/class/PassleSync.php";
+
+function plugin_activation() 
+{
+  Passle\PassleSync\PassleSync::activate();
+}
+
+function plugin_deactivation() 
+{
+  Passle\PassleSync\PassleSync::deactivate();
+}
+
+register_activation_hook(__FILE__, "plugin_activation");
+register_deactivation_hook(__FILE__, "plugin_deactivation");


### PR DESCRIPTION
Added functionality to the plugin so it has an option to create custom taxonomies from passle tag groups based on this option's value.

Introduced caching for tag group API calls so the calls to the API are a bit more efficient and a cron job that can be used to clear that cache and call the API again following tag groups changes that runs every hour but can also be manually invoked.

Fixed bugs around plugin activation and deactivation.