### PR TITLE
Hotfix/pas 13148   2024 01 30 1608   adding a featured post causes a 500 error

### DIFF
--- a/class/Actions/UpdateFeaturedPostAction.php
+++ b/class/Actions/UpdateFeaturedPostAction.php
@@ -3,12 +3,13 @@
 namespace Passle\PassleSync\Actions;
 
 use Passle\PassleSync\Utils\Utils;
-use WP_Error;
 
 class UpdateFeaturedPostAction
 {
   public static function execute(string $post_shortcode, bool $is_featured_on_passle_page, bool $is_featured_on_post_page)
   {
+    Utils::clear_featured_posts();
+
     $posts = get_posts([
       "post_type" => PASSLESYNC_POST_TYPE,
       "numberposts" => 1,
@@ -19,18 +20,16 @@ class UpdateFeaturedPostAction
         ],
       ],
     ]);
-
-    if (empty($posts)) return new WP_Error("404", "No post exists with the shortcode specified");
-    $post = $posts[0];
-
-    Utils::clear_featured_posts();
-
-    if ($is_featured_on_passle_page) {
-      update_post_meta($post->ID, "post_is_featured_on_passle_page", true);
-    }
-
-    if ($is_featured_on_post_page) {
-      update_post_meta($post->ID, "post_is_featured_on_post_page", true);
+    
+    if (!empty($posts)) {
+      $post = $posts[0];
+      if ($is_featured_on_passle_page) {
+        update_post_meta($post->ID, "post_is_featured_on_passle_page", true);
+      }
+  
+      if ($is_featured_on_post_page) {
+        update_post_meta($post->ID, "post_is_featured_on_post_page", true);
+      }
     }
   }
 }

--- a/class/Actions/UpdateFeaturedPostAction.php
+++ b/class/Actions/UpdateFeaturedPostAction.php
@@ -3,12 +3,16 @@
 namespace Passle\PassleSync\Actions;
 
 use Passle\PassleSync\Utils\Utils;
+use WP_Error;
 
 class UpdateFeaturedPostAction
 {
   public static function execute(string $post_shortcode, bool $is_featured_on_passle_page, bool $is_featured_on_post_page)
   {
     Utils::clear_featured_posts();
+
+    // if the shortcode is empty it means the featured post has been removed and therefore no need to continue. 
+    if (empty($post_shortcode)) return; 
 
     $posts = get_posts([
       "post_type" => PASSLESYNC_POST_TYPE,
@@ -20,16 +24,17 @@ class UpdateFeaturedPostAction
         ],
       ],
     ]);
-    
-    if (!empty($posts)) {
-      $post = $posts[0];
-      if ($is_featured_on_passle_page) {
-        update_post_meta($post->ID, "post_is_featured_on_passle_page", true);
-      }
-  
-      if ($is_featured_on_post_page) {
-        update_post_meta($post->ID, "post_is_featured_on_post_page", true);
-      }
+
+    if (empty($posts)) return new WP_Error("404", "No post exists with the shortcode specified");
+    $post = $posts[0];
+
+
+    if ($is_featured_on_passle_page) {
+      update_post_meta($post->ID, "post_is_featured_on_passle_page", true);
+    }
+
+    if ($is_featured_on_post_page) {
+      update_post_meta($post->ID, "post_is_featured_on_post_page", true);
     }
   }
 }

--- a/class/Utils/Utils.php
+++ b/class/Utils/Utils.php
@@ -48,10 +48,38 @@ class Utils
   {
     return max($min, min($max, $number));
   }
-
+  
   static function clear_featured_posts()
   {
-    delete_metadata("post", 0, "post_is_featured_on_passle_page", "", true);
-    delete_metadata("post", 0, "post_is_featured_on_post_page", "", true);
+    $args = array(
+      'post_type'      => PASSLESYNC_POST_TYPE,
+      'post_status'    => 'publish',
+      'posts_per_page' => -1,
+      'meta_query'     => array(
+        'relation' => 'OR',
+        array(
+          'key'   => 'post_is_featured_on_passle_page',
+          'compare' => 'EXISTS',
+        ),
+        array(
+          'key'   => 'post_is_featured_on_post_page',
+          'compare' => 'EXISTS',
+        ),
+      ),
+    );
+
+    $posts = get_posts($args);
+ 
+    foreach ($posts as $post) {
+      $post_meta = get_post_meta($post->ID, '', true);
+
+      if (isset($post_meta["post_is_featured_on_passle_page"]) && $post_meta["post_is_featured_on_passle_page"]) {
+        delete_post_meta($post->ID, "post_is_featured_on_passle_page");
+      }
+
+      if (isset($post_meta["post_is_featured_on_post_page"]) && $post_meta["post_is_featured_on_post_page"]) {
+        delete_post_meta($post->ID, "post_is_featured_on_post_page");
+      } 
+    }
   }
 }

--- a/class/Utils/Utils.php
+++ b/class/Utils/Utils.php
@@ -48,38 +48,10 @@ class Utils
   {
     return max($min, min($max, $number));
   }
-  
+
   static function clear_featured_posts()
   {
-    $args = array(
-      'post_type'      => PASSLESYNC_POST_TYPE,
-      'post_status'    => 'publish',
-      'posts_per_page' => -1,
-      'meta_query'     => array(
-        'relation' => 'OR',
-        array(
-          'key'   => 'post_is_featured_on_passle_page',
-          'compare' => 'EXISTS',
-        ),
-        array(
-          'key'   => 'post_is_featured_on_post_page',
-          'compare' => 'EXISTS',
-        ),
-      ),
-    );
-
-    $posts = get_posts($args);
- 
-    foreach ($posts as $post) {
-      $post_meta = get_post_meta($post->ID, '', true);
-
-      if (isset($post_meta["post_is_featured_on_passle_page"]) && $post_meta["post_is_featured_on_passle_page"]) {
-        delete_post_meta($post->ID, "post_is_featured_on_passle_page");
-      }
-
-      if (isset($post_meta["post_is_featured_on_post_page"]) && $post_meta["post_is_featured_on_post_page"]) {
-        delete_post_meta($post->ID, "post_is_featured_on_post_page");
-      } 
-    }
+    delete_metadata("post", 0, "post_is_featured_on_passle_page", "", true);
+    delete_metadata("post", 0, "post_is_featured_on_post_page", "", true);
   }
 }


### PR DESCRIPTION
Moved the function call to clear featured posts to prevent an early return error and fix the bug of not being able to remove a featured post. 