### PR TITLE
Fixed the error log statement in TaxonomyRegistryService

### DIFF
--- a/class/Services/TaxonomyRegistryService.php
+++ b/class/Services/TaxonomyRegistryService.php
@@ -62,7 +62,7 @@ class TaxonomyRegistryService
             );
                 
             if (is_wp_error($term)) {
-              error_log("Error creating term: $term " . $term->get_error_message() . PHP_EOL); 
+              error_log("Error creating term " . $tag . ": " . $term->get_error_message() . PHP_EOL); 
             }
           }
         }


### PR DESCRIPTION
Fixed the error log statement in TaxonomyRegistryService so it doesn't try to convert a WP_Error instance ($term) to a string but it should use the $tag that caused the error inside the error logged message