### PR TITLE
Changed WordpressContentServiceBase to avoid creating duplicates for scheduled posts vs live posts

### DIFF
--- a/class/Services/Content/Wordpress/WordpressContentServiceBase.php
+++ b/class/Services/Content/Wordpress/WordpressContentServiceBase.php
@@ -12,6 +12,7 @@ abstract class WordpressContentServiceBase extends ResourceClassBase
 
     $query = [
       "numberposts" => -1,
+	  "post_status" => array('publish', 'future'),
       "post_type" => [$resource->get_post_type()],
     ];
 


### PR DESCRIPTION
Changed WordpressContentServiceBase so it takes into account scheduled items when querying for WP content that has a passle post type