### PR TITLE
Fixed the response processing code in SyncHandlerBase

### DIFF
--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -216,14 +216,14 @@ abstract class SyncHandlerBase extends ResourceClassBase
         $response = call_user_func([$resource->passle_content_service_name, "get"], $next_url);
 
         // Validate the API response
-        if (!isset($response["Posts"])) {
+        if (!isset($response[ucfirst($resource->name_plural)])) {
             throw new Exception("Failed to get data from the API", 500);
         }
 
-        $response = $response["Posts"];
+        $response = $response[ucfirst($resource->name_plural)];
         
         if (empty($response)) {
-            break; // No more posts
+            break; // No more items
         }
 
         // Compare and process the items, update pending entities array


### PR DESCRIPTION
Updated SyncHandlerBase so it doesn't check for Posts in the response but check for either Posts or People based on which endpoint we call. Updated the comment as well to reflect that we don't just handle posts