### PR TITLE
Feature/pas 13594   2024 05 10 1451   make our wp plugin include tag aliases in the passle tag model if they exist as an array of strings or an empty array otherwise

### DIFF
--- a/class/Models/PasslePost.php
+++ b/class/Models/PasslePost.php
@@ -337,7 +337,8 @@ class PasslePost
   {
     return array_map(function ($tag) use ($wp_tags) {
       $matching_wp_tag = Utils::array_first($wp_tags, fn ($wp_tag) => $wp_tag->name === $tag) ?: null;
-      return new PassleTag($tag, $matching_wp_tag);
+      $matching_wp_tag_aliases = ( $aliases = get_term_meta($matching_wp_tag->term_id, "aliases", true) ) !== false ? $aliases : array();
+      return new PassleTag($tag, $matching_wp_tag, $matching_wp_tag_aliases);
     }, $tags);
   }
 

--- a/class/Models/PasslePost.php
+++ b/class/Models/PasslePost.php
@@ -105,7 +105,7 @@ class PasslePost
    * }
    * @return void
    */
-  public function __construct($wp_post, array $options = [])
+  public function __construct($wp_post, array $options = array())
   {
     $options = wp_parse_args($options, [
       "load_authors" => true,
@@ -282,23 +282,23 @@ class PasslePost
   private function initialize_tags(array $wp_tags)
   {
     if (isset($this->meta)) {
-      $tags = isset($this->meta["post_tags"]) ? $this->meta["post_tags"] : [];
+      $tags = isset($this->meta["post_tags"]) ? $this->meta["post_tags"] : array();
     } else {
       $tags = $this->passle_post["Tags"];
     }
 
-    $this->tags = $this->map_tags($tags ?? [], $wp_tags && is_array($wp_tags) ? $wp_tags : []);
+    $this->tags = $this->map_tags($tags ?? array(), $wp_tags && is_array($wp_tags) ? $wp_tags : array());
   }
 
   private function initialize_share_views()
   {
     if (isset($this->meta)) {
-      $share_views = isset($this->meta["post_share_views"]) ? $this->meta["post_share_views"] : [];
+      $share_views = isset($this->meta["post_share_views"]) ? $this->meta["post_share_views"] : array();
     } else {
-      $share_views = $this->passle_post["ShareViews"] ?? [];
+      $share_views = $this->passle_post["ShareViews"] ?? array();
     }
 
-    $this->share_views = $this->map_share_views($share_views ?? []);
+    $this->share_views = $this->map_share_views($share_views ?? array();
   }
 
   /*
@@ -326,7 +326,7 @@ class PasslePost
 
       $post_author = Utils::array_first($post_authors, fn ($post_author) => $post_author["shortcode"] === $author_shortcode);
       return $post_author;
-    }, $author_shortcodes ?? []);
+    }, $author_shortcodes ?? array());
 
     return array_map(fn ($author) => new PassleAuthor($author), $authors);
   }

--- a/class/Models/PasslePost.php
+++ b/class/Models/PasslePost.php
@@ -129,7 +129,11 @@ class PasslePost
     }
 
     if ($this->load_tags) {
-      $this->initialize_tags();
+      $all_wp_tags = get_tags(array(
+        'hide_empty' => false,   // To include tags with no posts
+        'number' => PHP_INT_MAX, // To retrieve all tags
+      ));
+      $this->initialize_tags($all_wp_tags);
     }
 
     $this->initialize_share_views();
@@ -275,7 +279,7 @@ class PasslePost
     }
   }
 
-  private function initialize_tags()
+  private function initialize_tags(array $wp_tags)
   {
     if (isset($this->meta)) {
       $tags = isset($this->meta["post_tags"]) ? $this->meta["post_tags"] : [];
@@ -283,13 +287,7 @@ class PasslePost
       $tags = $this->passle_post["Tags"];
     }
 
-    $wp_tags = get_tags();
-
-    if (!is_array($wp_tags)) {
-      $wp_tags = [];
-    }
-
-    $this->tags = $this->map_tags($tags ?? [], $wp_tags ?? []);
+    $this->tags = $this->map_tags($tags ?? [], $wp_tags && is_array($wp_tags) ? $wp_tags : []);
   }
 
   private function initialize_share_views()
@@ -336,7 +334,7 @@ class PasslePost
   private function map_tags(array $tags, array $wp_tags)
   {
     return array_map(function ($tag) use ($wp_tags) {
-      $matching_wp_tag = Utils::array_first($wp_tags, fn ($wp_tag) => $wp_tag->name === $tag) ?: null;
+      $matching_wp_tag = Utils::array_first($wp_tags, fn ($wp_tag) => html_entity_decode($wp_tag->name) === html_entity_decode($tag)) ?: null;
       $matching_wp_tag_aliases = ( $aliases = get_term_meta($matching_wp_tag->term_id, "aliases", true) ) !== false ? $aliases : array();
       return new PassleTag($tag, $matching_wp_tag, $matching_wp_tag_aliases);
     }, $tags);

--- a/class/Models/PasslePost.php
+++ b/class/Models/PasslePost.php
@@ -279,11 +279,11 @@ class PasslePost
   {
     if (isset($this->meta)) {
       $tags = isset($this->meta["post_tags"]) ? $this->meta["post_tags"] : [];
-      $wp_tags = get_the_tags();
     } else {
       $tags = $this->passle_post["Tags"];
-      $wp_tags = get_tags();
     }
+
+    $wp_tags = get_tags();
 
     if (!is_array($wp_tags)) {
       $wp_tags = [];

--- a/class/Models/PassleTag.php
+++ b/class/Models/PassleTag.php
@@ -20,7 +20,7 @@ class PassleTag
   private ?object $wp_tag;
 
   /** @internal */
-  public function __construct(string $name, ?object $wp_tag, ?array $aliases = [])
+  public function __construct(string $name, ?object $wp_tag, ?array $aliases = array())
   {
     $this->name = $name;
     $this->wp_tag = $wp_tag;

--- a/class/Models/PassleTag.php
+++ b/class/Models/PassleTag.php
@@ -14,14 +14,17 @@ class PassleTag
   public string $slug;
   /** The link to view posts associated with the tag. */
   public string $url;
+  /** The aliases associated with the tag. */
+  public ?array $aliases;
 
   private ?object $wp_tag;
 
   /** @internal */
-  public function __construct(string $name, ?object $wp_tag)
+  public function __construct(string $name, ?object $wp_tag, ?array $aliases = [])
   {
     $this->name = $name;
     $this->wp_tag = $wp_tag;
+    $this->aliases = $aliases;
     $this->initialize();
   }
 

--- a/class/Services/Content/Passle/PassleContentServiceBase.php
+++ b/class/Services/Content/Passle/PassleContentServiceBase.php
@@ -140,10 +140,14 @@ abstract class PassleContentServiceBase extends ResourceClassBase
       ->path("passlesync/{$resource->name_plural}")
       ->parameters($params)
       ->build();
-
+    
     $response = static::get($url);
-    $data = $response[ucfirst($resource->name_plural)];
-
+    if ($response) {
+      $data = $response[ucfirst($resource->name_plural)];
+    } else {
+      $data = array();
+    }
+    
     static::update_cache($data);
 
     return $data;

--- a/class/SyncHandlers/AuthorHandler.php
+++ b/class/SyncHandlers/AuthorHandler.php
@@ -9,6 +9,19 @@ class AuthorHandler extends SyncHandlerBase
 {
   const RESOURCE = PersonResource::class;
 
+  protected static function pre_sync_all_hook()
+  { }
+
+  protected static function post_sync_all_hook()
+  { 
+    do_action("passle_author_sync_all_complete");
+  }
+
+  protected static function post_sync_one_hook(int $entity_id)
+  { 
+    do_action("passle_author_sync_one_complete", $entity_id);
+  }
+
   protected static function map_data(array $data, int $entity_id)
   {
     $postarr = [

--- a/class/SyncHandlers/PostHandler.php
+++ b/class/SyncHandlers/PostHandler.php
@@ -17,9 +17,27 @@ class PostHandler extends SyncHandlerBase
     Utils::clear_featured_posts();
   }
 
+  protected static function post_sync_all_hook()
+  {
+      do_action("passle_post_sync_all_complete");
+  }
+
+  protected static function post_sync_one_hook(int $entity_id)
+  {
+     do_action("passle_post_sync_one_complete", $entity_id);
+  }
+
   protected static function map_data(array $data, int $entity_id)
   {
+    $tags_with_aliases = array();
     $tags = static::map_tags_and_aliases($data["TagMappings"]);
+    foreach($tags as $tag) {
+      foreach($data["TagMappings"] as $tag_mapping){
+        if($tag_mapping['Tag'] === $tag){
+          array_push($tags_with_aliases, array( $tag => array("aliases" => $tag_mapping["Aliases"])));
+        }
+      }
+    }
     $postarr = [
       "ID" => $entity_id,
       "post_title" => $data["PostTitle"],
@@ -46,6 +64,7 @@ class PostHandler extends SyncHandlerBase
         "post_is_repost" => $data["IsRepost"],
         "post_estimated_read_time" => $data["EstimatedReadTimeInSeconds"],
         "post_tags" => $tags,
+        "post_tags_with_aliases" => $tags_with_aliases,
         "post_tag_group_tags" => $tags,
         "post_image_url" => $data["ImageUrl"],
         "post_featured_item_html" => $data["FeaturedItemHtml"],

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -7,7 +7,6 @@ use Passle\PassleSync\Utils\ResourceClassBase;
 use Passle\PassleSync\Utils\Utils;
 use Passle\PassleSync\Utils\UrlFactory;
 use Passle\PassleSync\Services\OptionsService;
-use Passle\PassleSync\Actions\Resources\PeopleWebhookActions;
 
 abstract class SyncHandlerBase extends ResourceClassBase
 {

--- a/passle-sync.php
+++ b/passle-sync.php
@@ -3,7 +3,7 @@
   Plugin Name: Passle Sync
   Plugin URI: https://github.com/passle/passle-sync-wordpress
   Description: This plugin will sync your Passle posts and authors into your WordPress instance.
-  Version: 2.1.0
+  Version: 2.2.0
   Author: Passle
   Author URI: https://www.passle.net
   License: MIT


### PR DESCRIPTION
- Added aliases to tags created by passle so they can be accessed within the PasslePost model tags property.
- Removed code that was checking for authors and attempted to resync them as this code was causing issues in the sync base class.
- Fixed bug with mapping tags when initializing a post, whereby tags with special characters were not being mapped correctly.