### PR TITLE
Clear taxonomy terms on posts before re-setting them during post sync

### DIFF
--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -190,6 +190,8 @@ abstract class SyncHandlerBase extends ResourceClassBase
     if (!empty($postarr_arrays["post_tag_group_tags"]) && $options->include_passle_tag_groups) {
       $taxonomies = get_taxonomies(array("object_type" => array(PASSLESYNC_POST_TYPE), "public" => true, "_builtin" => false));
       foreach ($taxonomies as $taxonomy) {
+        // Remove all terms for the given taxonomy by setting terms to an empty array
+        wp_set_object_terms($post_id, array(), $taxonomy);
         foreach ($postarr_arrays["post_tag_group_tags"] as $tag) {
           $term = get_term_by("name", $tag, $taxonomy);
           if ($term != null && $term->name && $term->taxonomy) {


### PR DESCRIPTION
Before setting a post's terms for a given taxonomy - if the relevant setting is selected in the WP plugin, we need to first reset all terms that exist on the post for the taxonomy. This way, tag group tags removal from posts gets correctly reflected when syncing