### PR TITLE
Added primary_email_address to the author mapping code we run when syncing posts

### DIFF
--- a/class/SyncHandlers/PostHandler.php
+++ b/class/SyncHandlers/PostHandler.php
@@ -96,6 +96,7 @@ class PostHandler extends SyncHandlerBase
     return array_map(fn ($author) => [
       "shortcode" => $author["Shortcode"],
       "name" => $author["Name"],
+      "primary_email_address" => $author["EmailAddress"],
       "image_url" => $author["ImageUrl"],
       "profile_url" => $author["ProfileUrl"],
       "role" => $author["Role"],


### PR DESCRIPTION
Added primary_email_address to the author mapping code we run when syncing posts so that this information is accessible via $passle_post authors property for each author