### PR TITLE
Made get_term_meta return an array always

### DIFF
--- a/class/Models/PasslePost.php
+++ b/class/Models/PasslePost.php
@@ -335,7 +335,7 @@ class PasslePost
   {
     return array_map(function ($tag) use ($wp_tags) {
       $matching_wp_tag = Utils::array_first($wp_tags, fn ($wp_tag) => html_entity_decode($wp_tag->name) === html_entity_decode($tag)) ?: null;
-      $matching_wp_tag_aliases = ( $aliases = get_term_meta($matching_wp_tag->term_id, "aliases", true) ) !== false ? $aliases : array();
+      $matching_wp_tag_aliases = ( $aliases = get_term_meta($matching_wp_tag->term_id, "aliases", false) ) !== false ? $aliases : array();
       return new PassleTag($tag, $matching_wp_tag, $matching_wp_tag_aliases);
     }, $tags);
   }


### PR DESCRIPTION
Looks like get_term_meta can return either a string or an array if the third argument is true. However, using false will force it to return an array even if it only finds 1 value. This is what we need in the context of this code as the PassleTag constructor expects an optional array as a third argument and in no case, a string