### PR TITLE
Updated hook to accept $tag_groups

### DIFF
--- a/class/SyncHandlers/AuthorHandler.php
+++ b/class/SyncHandlers/AuthorHandler.php
@@ -17,7 +17,7 @@ class AuthorHandler extends SyncHandlerBase
     do_action("passle_author_sync_all_complete");
   }
 
-  protected static function post_sync_one_hook(int $entity_id)
+  protected static function post_sync_one_hook(int $entity_id, array $tag_groups = [])
   { 
     delete_post_meta($entity_id, '_pending_deletion');
     do_action("passle_author_sync_one_complete", $entity_id);

--- a/class/SyncHandlers/PostHandler.php
+++ b/class/SyncHandlers/PostHandler.php
@@ -23,10 +23,10 @@ class PostHandler extends SyncHandlerBase
     do_action("passle_post_sync_all_complete");
   }
 
-  protected static function post_sync_one_hook(int $entity_id)
+  protected static function post_sync_one_hook(int $entity_id, array $tag_groups = [])
   {
     delete_post_meta($entity_id, '_pending_deletion');
-    do_action("passle_post_sync_one_complete", $entity_id);
+    do_action("passle_post_sync_one_complete", $entity_id, $tag_groups);
   }
 
   protected static function get_last_synced_page()

--- a/class/SyncHandlers/SyncHandlerBase.php
+++ b/class/SyncHandlers/SyncHandlerBase.php
@@ -16,7 +16,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
 
   protected abstract static function post_sync_all_hook();
 
-  protected abstract static function post_sync_one_hook(int $entity_id);
+  protected abstract static function post_sync_one_hook(int $entity_id, array $tag_groups = []);
 
   protected abstract static function get_last_synced_page();
 
@@ -207,9 +207,11 @@ abstract class SyncHandlerBase extends ResourceClassBase
     unset($postarr_arrays["post_tags_with_aliases"]);
 
     // Set post taxonomy terms based on tags
+    $tag_groups = [];
     if (!empty($postarr_arrays["post_tag_group_tags"]) && $options->include_passle_tag_groups) {
       $taxonomies = get_taxonomies(array("object_type" => array(PASSLESYNC_POST_TYPE), "public" => true, "_builtin" => false));
       foreach ($taxonomies as $taxonomy) {
+        $tags = [];
         // Remove all terms for the given taxonomy by setting terms to an empty array
         wp_set_object_terms($post_id, array(), $taxonomy);
         foreach ($postarr_arrays["post_tag_group_tags"] as $tag) {
@@ -218,9 +220,17 @@ abstract class SyncHandlerBase extends ResourceClassBase
             $result = wp_set_object_terms($post_id, $term->name, $term->taxonomy, true);
             if (is_wp_error($result)) {
               error_log("Failed to assign term " .$term->name. " to taxonomy " .$taxonomy. " on post ID: " .$post_id. ". " .$result->get_error_message());
+            } else {
+              $tags[] = html_entity_decode($term->name);
             }
           }
         }
+        $taxonomy_object = get_taxonomy($taxonomy);
+        $taxonomy_label = $taxonomy_object ? $taxonomy_object->label : $taxonomy; // fall back to slug
+        $tag_groups[] = [
+          "Name"=> $taxonomy_label,
+          "Tags"=> $tags
+        ];
       }
     }
     unset($postarr_arrays["post_tag_group_tags"]);
@@ -236,7 +246,7 @@ abstract class SyncHandlerBase extends ResourceClassBase
 
     $postarr["ID"] = $post_id;
 
-    static::post_sync_one_hook($post_id);
+    static::post_sync_one_hook($post_id, $tag_groups);
 
     return $postarr;
   }


### PR DESCRIPTION
Updated post_sync_one_hook so it accepts tag groups as the second parameter so that the post handler can return it to the callback do_action. Also, updated SyncHandlerBase to pass the actual tag groups to this sync hook